### PR TITLE
Set version with NEUTIS_DISTRO_VERSION

### DIFF
--- a/meta-neutis-distro/conf/distro/poky-neutis.conf
+++ b/meta-neutis-distro/conf/distro/poky-neutis.conf
@@ -3,7 +3,7 @@ require conf/distro/poky.conf
 POKY_VERSION := "${DISTRO_VERSION}"
 DISTRO = "poky-neutis"
 DISTRO_NAME = "Poky Neutis (Emlid Neutis Linux Distro)"
-DISTRO_VERSION = "1.0.3"
+DISTRO_VERSION = "${NEUTIS_DISTRO_VERSION}"
 
 DISTRO_FEATURES += "systemd sysvinit"
 


### PR DESCRIPTION
Merge only with [PR](https://github.com/Neutis/neutis-image/pull/2) or it will broke build.

Since all meta-layers can affect the version of distro it will be better to set it in [build repo](https://github.com/Neutis/neutis-image).