### PR TITLE
Neutis mender support & small fixes

### DIFF
--- a/meta-neutis-bsp/conf/machine/neutis-n5.conf
+++ b/meta-neutis-bsp/conf/machine/neutis-n5.conf
@@ -9,7 +9,7 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-sunxi"
 MANUFACTURER = "allwinner"
 
 PREFERRED_VERSION_linux = "4.17+git%"
-PREFERRED_VERSION_u-boot = "v2018.01%"
+PREFERRED_VERSION_u-boot = "v2018.07%"
 
 KERNEL_DEVICETREE = "${MANUFACTURER}/sun50i-h5-emlid-neutis-n5.dtb \
                      ${MANUFACTURER}/sun50i-h5-emlid-neutis-n5-devboard.dtb \
@@ -34,6 +34,7 @@ KERNEL_DEVICETREE = "${MANUFACTURER}/sun50i-h5-emlid-neutis-n5.dtb \
                      ${MANUFACTURER}/overlay/sun50i-h5-camera-status-okay.dtbo \
                     "
 UBOOT_MACHINE = "emlid_neutis_n5_defconfig"
+SPL_BINARY = "u-boot-sunxi-with-spl.bin"
 
 DEFAULTTUNE = "aarch64"
 

--- a/meta-neutis-bsp/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/meta-neutis-bsp/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -1,16 +1,17 @@
 DESCRIPTION="Upstream's U-boot fw-utils configured for Neutis"
 FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot/:"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 
 inherit pythonnative
 
-DEPENDS += "dtc-native swig-native python-dev python-native"
+DEPENDS += "dtc-native swig-native python-native"
 
 SRC_URI = "git://git.denx.de/u-boot.git;protocol=https \
-           file://0001-arm-sunxi-new-board-Emlid-Neutis-N5.patch \
+           file://0001-v2018_07-arch-arm-new-board-Emlid-Neutis-N5-support.patch \
            "
-SRCREV = "f3dd87e0b98999a78e500e8c6d2b063ebadf535a"
+SRCREV = "8c5d4fd0ec222701598a27b26ab7265d4cee45a3"
 
-PV = "v2018.01+git${SRCPV}"
+PV = "v2018.07+git${SRCPV}"
 
 do_compile () {
     oe_runmake ${UBOOT_MACHINE}

--- a/meta-neutis-bsp/recipes-bsp/u-boot/u-boot/0001-v2018_07-arch-arm-new-board-Emlid-Neutis-N5-support.patch
+++ b/meta-neutis-bsp/recipes-bsp/u-boot/u-boot/0001-v2018_07-arch-arm-new-board-Emlid-Neutis-N5-support.patch
@@ -1,37 +1,41 @@
-From 033ad8d77123de267f14fad146bec170b3120cb4 Mon Sep 17 00:00:00 2001
+From 20ca073187da2e5fe16a350eadf4565a415e2b2e Mon Sep 17 00:00:00 2001
 From: AD-Aleksandrov <aleksandr.aleksandrov@emlid.com>
-Date: Sat, 10 Mar 2018 18:27:30 +0300
-Subject: [PATCH] arm: sunxi: new board Emlid Neutis N5 that based on Allwinner
- H5 - add defconfig and DT file to boot from eMMC
+Date: Wed, 5 Sep 2018 15:40:18 +0300
+Subject: [PATCH] arch: arm: new board - Emlid Neutis N5 support
 
+- add neutis target to dtb makefile
+- add dts file for Neutis N5
+- add config file for Neutis N5
+
+Signed-off-by: Aleksandr Aleksandrov <aleksandr.aleksandrov@emlid.com>
 ---
  arch/arm/dts/Makefile                      |  3 +-
- arch/arm/dts/sun50i-h5-emlid-neutis-n5.dts | 93 ++++++++++++++++++++++++++++++
+ arch/arm/dts/sun50i-h5-emlid-neutis-n5.dts | 90 ++++++++++++++++++++++++++++++
  configs/emlid_neutis_n5_defconfig          | 17 ++++++
- 3 files changed, 112 insertions(+), 1 deletion(-)
+ 3 files changed, 109 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm/dts/sun50i-h5-emlid-neutis-n5.dts
  create mode 100644 configs/emlid_neutis_n5_defconfig
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index a895c70..6718785 100644
+index 9460230..d052534 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -349,7 +349,8 @@ dtb-$(CONFIG_MACH_SUN50I_H5) += \
- 	sun50i-h5-nanopi-neo-plus2.dtb \
+@@ -384,7 +384,8 @@ dtb-$(CONFIG_MACH_SUN50I_H5) += \
+ 	sun50i-h5-orangepi-zero-plus.dtb \
  	sun50i-h5-orangepi-pc2.dtb \
  	sun50i-h5-orangepi-prime.dtb \
 -	sun50i-h5-orangepi-zero-plus2.dtb
 +	sun50i-h5-orangepi-zero-plus2.dtb \
 +	sun50i-h5-emlid-neutis-n5.dtb
  dtb-$(CONFIG_MACH_SUN50I) += \
+ 	sun50i-a64-amarula-relic.dtb \
  	sun50i-a64-bananapi-m64.dtb \
- 	sun50i-a64-nanopi-a64.dtb \
 diff --git a/arch/arm/dts/sun50i-h5-emlid-neutis-n5.dts b/arch/arm/dts/sun50i-h5-emlid-neutis-n5.dts
 new file mode 100644
-index 0000000..8cbda20
+index 0000000..deb6e76
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h5-emlid-neutis-n5.dts
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,90 @@
 +/*s
 + * Copyright (C) 2018 Aleksandr Aleksandrov <aleksandr.aleksandrov@emlid.com>
 + *
@@ -101,12 +105,9 @@ index 0000000..8cbda20
 +};
 +
 +&mmc0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc0_pins_a>, <&mmc0_cd_pin>;
 +	vmmc-supply = <&reg_vcc3v3>;
 +	bus-width = <4>;
-+	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
-+	cd-inverted;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
 +	status = "okay";
 +};
 +

--- a/meta-neutis-bsp/recipes-bsp/u-boot/u-boot/boot.cmd
+++ b/meta-neutis-bsp/recipes-bsp/u-boot/u-boot/boot.cmd
@@ -4,35 +4,48 @@
 #
 
 setenv loglevel "10"
-setenv rootdev "/dev/mmcblk0p2"
+setenv rootdev "/dev/mmcblk0"
 setenv initrd_addr_r "0x41080000"
 setenv load_addr "0x44000000"
 setenv overlay_error "false"
+setenv device "0"
+setenv prefix ""
 
 if itest.b *0x10028 == 0x00 ; then
-        echo "U-boot loaded from SD"
-        setenv rootdev "/dev/mmcblk0p2"
+    echo "U-boot loaded from SD"
+    setenv device "0"
+    setenv rootdev "/dev/mmcblk0"
 fi
 
 if itest.b *0x10028 == 0x02 ; then
-        echo "U-boot loaded from eMMC"
-        setenv rootdev "/dev/mmcblk2p2"
+    echo "U-boot loaded from eMMC"
+    setenv device "1"
+    setenv rootdev "/dev/mmcblk2"
 fi
 
-if test -e mmc ${devnum} Env.txt; then
-    load mmc ${devnum} ${load_addr} Env.txt
+# Configure env for mender distribution
+if env exists mender_boot_part; then
+    setenv device "${device}:${mender_boot_part}"
+    setenv rootdev "${rootdev}p${mender_boot_part}"
+    setenv prefix "boot/"
+else
+    setenv rootdev "${rootdev}p2"
+fi
+
+if test -e mmc ${device} ${prefix}Env.txt; then
+    load mmc ${device} ${load_addr} ${prefix}Env.txt
     env import -t ${load_addr} ${filesize}
 fi
 
 setenv bootargs "console=${console} earlyprintk root=${rootdev} rw rootwait fsck.repair=yes panic=10 loglevel=${loglevel}"
 
 # Load DT file
-load mmc ${devnum} ${fdt_addr_r} ${fdtfile}
+load mmc ${device} ${fdt_addr_r} ${prefix}${fdtfile}
 fdt addr ${fdt_addr_r}
 fdt resize 65536
 
 for overlay in ${overlays}; do
-    if load mmc ${devnum} ${load_addr} allwinner/overlay/sun50i-h5-${overlay}.dtbo; then
+    if load mmc ${device} ${load_addr} ${prefix}allwinner/overlay/sun50i-h5-${overlay}.dtbo; then
         echo "Applying DT overlay sun50i-h5-${overlay}.dtbo"
         fdt apply ${load_addr} || setenv overlay_error "true"
     fi
@@ -40,12 +53,12 @@ done
 
 if test "${overlay_error}" = "true"; then
     echo "Error applying DT overlays, restoring original DT"
-    load mmc ${devnum} ${fdt_addr_r} ${fdtfile}
+    load mmc ${device} ${fdt_addr_r} ${prefix}${fdtfile}
 fi
 
-load mmc ${devnum} ${kernel_addr_r} Image
+load mmc ${device} ${kernel_addr_r} ${prefix}Image
 
-if load mmc ${devnum} ${initrd_addr_r} uInitrd; then
+if load mmc ${device} ${initrd_addr_r} ${prefix}uInitrd; then
     booti ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr_r}
 else
     booti ${kernel_addr_r} - ${fdt_addr_r}

--- a/meta-neutis-bsp/recipes-bsp/u-boot/u-boot_2018.07.bb
+++ b/meta-neutis-bsp/recipes-bsp/u-boot/u-boot_2018.07.bb
@@ -7,7 +7,7 @@ inherit pythonnative
 PROVIDES += "u-boot"
 RPROVIDES_${PN} += "u-boot"
 
-DEPENDS += "dtc-native swig-native python-dev python-native"
+DEPENDS += "dtc-native swig-native python-native"
 DEPENDS_append_sun50i += "atf-sunxi"
 
 LICENSE = "GPLv2"
@@ -29,20 +29,17 @@ COMPATIBLE_MACHINE = "(sun50i)"
 
 DEFAULT_PREFERENCE_sun50i="1"
 SRC_URI = "git://git.denx.de/u-boot.git;protocol=https \
-           file://0001-arm-sunxi-new-board-Emlid-Neutis-N5.patch \
+           file://0001-v2018_07-arch-arm-new-board-Emlid-Neutis-N5-support.patch \
            file://boot.cmd \
            file://Env.txt \
            "
 
-SRCREV = "f3dd87e0b98999a78e500e8c6d2b063ebadf535a"
+SRCREV = "8c5d4fd0ec222701598a27b26ab7265d4cee45a3"
 
-PV = "v2018.01+git${SRCPV}"
+PV = "v2018.07+git${SRCPV}"
 PE = "2"
 
 S = "${WORKDIR}/git"
-
-SPL_BINARY = "spl/sunxi-spl.bin"
-UBOOT_BINARY = "u-boot.itb"
 
 UBOOT_ENV_SUFFIX = "scr"
 UBOOT_ENV = "boot"
@@ -57,5 +54,4 @@ do_compile_sun50i[depends] += "atf-sunxi:do_deploy"
 
 do_compile_append() {
     ${B}/tools/mkimage -C none -A arm -T script -d ${WORKDIR}/boot.cmd ${WORKDIR}/${UBOOT_ENV_BINARY}
-    cat ${SPL_BINARY} ${UBOOT_BINARY} > ${DEPLOY_DIR_IMAGE}/u-boot-sunxi-with-spl.bin
 }

--- a/meta-neutis-bsp/recipes-connectivity/openssl/openssl.inc
+++ b/meta-neutis-bsp/recipes-connectivity/openssl/openssl.inc
@@ -21,7 +21,7 @@ TERMIO_libc-musl = "-DTERMIOS"
 TERMIO ?= "-DTERMIO"
 # Avoid binaries being marked as requiring an executable stack since it 
 # doesn't(which causes and this causes issues with SELinux
-CFLAG = "${@base_conditional('SITEINFO_ENDIANNESS', 'le', '-DL_ENDIAN', '-DB_ENDIAN', d)} \
+CFLAG = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'le', '-DL_ENDIAN', '-DB_ENDIAN', d)} \
 	 ${TERMIO} ${CFLAGS} -Wall -Wa,--noexecstack"
 
 export DIRS = "crypto ssl apps"

--- a/meta-neutis-bsp/recipes-core/images/neutis-image.bb
+++ b/meta-neutis-bsp/recipes-core/images/neutis-image.bb
@@ -56,7 +56,7 @@ IMAGE_INSTALL_append += "python"
 IMAGE_INSTALL_append += "python-dbus python-pygobject python-argparse"
 IMAGE_INSTALL_append += "python-distutils python-pkgutil python-netserver"
 IMAGE_INSTALL_append += "python-xmlrpc python-ctypes python-html python-json python-compile"
-IMAGE_INSTALL_append += "python-misc python-numbers python-unittest python-pydoc python-importlib"
+IMAGE_INSTALL_append += "python-misc python-numbers python-unittest python-pydoc"
 
 # BSP
 IMAGE_INSTALL_append += "reflash-utility"
@@ -66,7 +66,9 @@ PREFERRED_VERSION_openssl = "1.0.2k"
 IMAGE_INSTALL_append += "openssl-atecc508a openssl-atecc508a-dev"
 IMAGE_INSTALL_append += "neutis-initramfs"
 
-inherit core-image
+inherit core-image allwinner-overlays
+
+ROOTFS_PREPROCESS_COMMAND_append += "deploy_allwinner_device_tree_blobs; "
 
 ROOTFS_POSTPROCESS_COMMAND += "clean_boot_dir ; "
 

--- a/meta-neutis-bsp/recipes-kernel/linux/linux-sunxi_4.17.bb
+++ b/meta-neutis-bsp/recipes-kernel/linux/linux-sunxi_4.17.bb
@@ -46,5 +46,4 @@ SRC_URI += "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.gi
         file://0021-neutis-add-cooling-maps-and-update-opp.patch \
         "
 
-
 S = "${WORKDIR}/git"

--- a/meta-neutis-distro/conf/distro/poky-neutis-mender.conf
+++ b/meta-neutis-distro/conf/distro/poky-neutis-mender.conf
@@ -1,0 +1,22 @@
+require poky-neutis.conf
+
+DISTRO = "poky-neutis-mender"
+
+INHERIT += "mender-full"
+MENDER_ARTIFACT_NAME = "release-1"
+MENDER_FEATURES_ENABLE_append = " mender-uboot"
+
+MENDER_STORAGE_DEVICE = "/dev/mmcblk2"
+
+MENDER_IMAGE_BOOTLOADER_FILE = "u-boot-sunxi-with-spl.bin"
+IMAGE_BOOT_FILES_append = " boot.scr"
+ARTIFACTIMG_FSTYPE = "ext4"
+IMAGE_OVERHEAD_FACTOR = "1.0"
+IMAGE_FSTYPES = "sdimg"
+
+MENDER_STORAGE_TOTAL_SIZE_MB = "1600"
+MENDER_UBOOT_STORAGE_DEVICE = "1"
+MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "16"
+
+MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
+MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"

--- a/meta-neutis-distro/recipes-core/images/neutis-image.bbappend
+++ b/meta-neutis-distro/recipes-core/images/neutis-image.bbappend
@@ -2,3 +2,6 @@ IMAGE_INSTALL_append += "coreutils"
 IMAGE_INSTALL_append += "util-linux"
 IMAGE_INSTALL_append += "u-boot-fw-utils"
 
+# Mender
+# require recipes-core/images/neutis-mender-image.inc
+

--- a/meta-neutis-distro/recipes-core/images/neutis-mender-image.inc
+++ b/meta-neutis-distro/recipes-core/images/neutis-mender-image.inc
@@ -1,0 +1,9 @@
+ROOTFS_POSTPROCESS_COMMAND += "bootstrap_boot_directory ; "
+
+bootstrap_boot_directory () {
+    cp -r ${DEPLOY_DIR_IMAGE}/allwinner ${IMAGE_ROOTFS}/boot/
+    cp ${DEPLOY_DIR_IMAGE}/Image ${IMAGE_ROOTFS}/boot/Image
+    cp ${DEPLOY_DIR_IMAGE}/Env.txt ${IMAGE_ROOTFS}/boot/
+    cp ${DEPLOY_DIR_IMAGE}/uInitrd ${IMAGE_ROOTFS}/boot/uInitrd
+}
+


### PR DESCRIPTION
- mender support, disabled by default
- fix allwinner device tree files copying
- bump u-boot version 2018.07
- adapt boot.scr for mender u-boot