### PR TITLE
bsp: kernel: linux: 4.17: fix kernel compilation warning

### DIFF
--- a/meta-neutis-bsp/recipes-kernel/linux/linux-sunxi_4.17.bb
+++ b/meta-neutis-bsp/recipes-kernel/linux/linux-sunxi_4.17.bb
@@ -12,7 +12,7 @@ inherit kernel
 require recipes-kernel/linux/linux.inc
 
 # Pull in the devicetree files into the rootfs
-RDEPENDS_kernel-base += "kernel-devicetree"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 
 # Default is to use stable kernel version
 # If you want to use latest git version set to "1"


### PR DESCRIPTION
Fix "WARNING: Variable key RDEPENDS_${KERNEL_PACKAGE_NAME}-base
(${KERNEL_PACKAGE_NAME}-image) replaces original key
RDEPENDS_kernel-base"

The fix is described here
https://lists.bootlin.com/pipermail/training-materials-updates/2018q3/002622.html