### PR TITLE
Fix ATF dependency in U-Boot recipe

### DIFF
--- a/meta-neutis-bsp/recipes-bsp/u-boot/u-boot_2018.07.bb
+++ b/meta-neutis-bsp/recipes-bsp/u-boot/u-boot_2018.07.bb
@@ -50,7 +50,7 @@ do_configure_append() {
 
 EXTRA_OEMAKE_append_sun50i = " BL31=${DEPLOY_DIR_IMAGE}/bl31.bin "
 
-do_compile_sun50i[depends] += "atf-sunxi:do_deploy"
+do_compile_sun50i[depends] += "atf-sunxi:do_install"
 
 do_compile_append() {
     ${B}/tools/mkimage -C none -A arm -T script -d ${WORKDIR}/boot.cmd ${WORKDIR}/${UBOOT_ENV_BINARY}


### PR DESCRIPTION
It seems like the recipe doesn't take into account that we need to have
ATF prior to compiling the U-Boot.